### PR TITLE
enable pango markup interpretation by genmon plugin

### DIFF
--- a/plugins/genmon/genmon.c
+++ b/plugins/genmon/genmon.c
@@ -31,6 +31,7 @@ typedef struct {
     int time;
     int timer;
     int max_text_len;
+    int allow_pango_markup;
     char *command;
     char *textsize;
     char *textcolor;
@@ -41,24 +42,40 @@ static int
 text_update(genmon_priv *gm)
 {
     FILE *fp;  
-    char text[256];
+    char *text;
+    int text_len;
     char *markup;
     int len;
 
     ENTER;
     fp = popen(gm->command, "r");
-    if (fgets(text, sizeof(text), fp));
+    /* allow for multi-byte characters and a null-terminator */
+    text_len = (4 * gm->max_text_len) + 1;
+    text = malloc(text_len);
+    if (text == NULL) {
+	/* ignore for now; try again later */
+	RET(TRUE);
+    }
+    /* Ensure null-termination even if read fails */
+    text[0] = 0;
+    if (fgets(text, text_len, fp));
     pclose(fp);
     len = strlen(text) - 1;
     if (len >= 0) {
         if (text[len] == '\n')
             text[len] = 0;
         
-        markup = g_markup_printf_escaped(FMT, gm->textsize, gm->textcolor,
-            text);
-        gtk_label_set_markup (GTK_LABEL(gm->main), markup);
-        g_free(markup);
+        if (gm->allow_pango_markup) {
+            gtk_label_set_markup (GTK_LABEL(gm->main), text);
+        }
+        else {
+            markup = g_markup_printf_escaped(FMT, gm->textsize, gm->textcolor,
+                                             text);
+            gtk_label_set_markup (GTK_LABEL(gm->main), markup);
+            g_free(markup);
+        }
     }
+    free(text);
     RET(TRUE);
 }
 
@@ -86,12 +103,14 @@ genmon_constructor(plugin_instance *p)
     gm->textsize = "medium";
     gm->textcolor = "darkblue";
     gm->max_text_len = 30;
+    gm->allow_pango_markup = 0;
     
     XCG(p->xc, "Command", &gm->command, str);
     XCG(p->xc, "TextSize", &gm->textsize, str);
     XCG(p->xc, "TextColor", &gm->textcolor, str);
     XCG(p->xc, "PollingTime", &gm->time, int);
     XCG(p->xc, "MaxTextLength", &gm->max_text_len, int);
+    XCG(p->xc, "AllowPangoMarkup", &gm->allow_pango_markup, int);
     
     gm->main = gtk_label_new(NULL);
     gtk_label_set_max_width_chars(GTK_LABEL(gm->main), gm->max_text_len);


### PR DESCRIPTION
[This is identical to #19 except against develop.]

Sometime about five years ago, I coded a small patch to the genmon plugin to allow pango-style font markup to be rendered. I use this for a little monitor that I have to enable it to color certain text and to display in a fixed-width font.

This image:

![genmon-pango](https://cloud.githubusercontent.com/assets/997128/11666427/7231d4a2-9dba-11e5-9676-90c7b8f7c1e8.png)

is generated by this text: `<tt><span size='larger' foreground='red'>● </span><span foreground='red'>A</span> <span foreground='red'>Q</span> <span foreground='#266522'>v</span> <span foreground='#266522'>/vsm</span><span size='larger' foreground='red'> ●</span></tt>`

The patch adds the `AllowPangoMarkup` configuration to enable this. I have the following stanza in `~/.config/fbpanel/default`:

```
Plugin {
    type = genmon
    config {
        Command = get_qbiff_output
    AllowPangoMarkup = 1
    PollingTime = 1
    MaxTextLength = 500
    }
}
```

See the commit comment for additional notes.

I've been using this enhancement for about 5 years without any trouble.

By the way, I love fbpanel. It fits perfectly with my minimalistic desktop environment. I use it with openbox.

I previously submitted this as https://sourceforge.net/tracker/?func=detail&aid=3131882&group_id=66031&atid=513127

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=640356

I hope you will consider accepting this enhancement.
