### PR TITLE
enable pango markup interpretation by genmon plugin

### DIFF
--- a/plugins/genmon/genmon.c
+++ b/plugins/genmon/genmon.c
@@ -31,6 +31,7 @@ typedef struct {
     int time;
     int timer;
     int max_text_len;
+    int allow_pango_markup;
     char *command;
     char *textsize;
     char *textcolor;
@@ -41,24 +42,40 @@ static int
 text_update(genmon_priv *gm)
 {
     FILE *fp;  
-    char text[256];
+    char *text;
+    int text_len;
     char *markup;
     int len;
 
     ENTER;
     fp = popen(gm->command, "r");
-    if (fgets(text, sizeof(text), fp));
+    /* allow for multi-byte characters and a null-terminator */
+    text_len = (4 * gm->max_text_len) + 1;
+    text = malloc(text_len);
+    if (text == NULL) {
+	/* ignore for now; try again later */
+	RET(TRUE);
+    }
+    /* Ensure null-termination even if read fails */
+    text[0] = 0;
+    if (fgets(text, text_len, fp));
     pclose(fp);
     len = strlen(text) - 1;
     if (len >= 0) {
         if (text[len] == '\n')
             text[len] = 0;
         
-        markup = g_markup_printf_escaped(FMT, gm->textsize, gm->textcolor,
-            text);
-        gtk_label_set_markup (GTK_LABEL(gm->main), markup);
-        g_free(markup);
+        if (gm->allow_pango_markup) {
+            gtk_label_set_markup (GTK_LABEL(gm->main), text);
+        }
+        else {
+            markup = g_markup_printf_escaped(FMT, gm->textsize, gm->textcolor,
+                                             text);
+            gtk_label_set_markup (GTK_LABEL(gm->main), markup);
+            g_free(markup);
+        }
     }
+    free(text);
     RET(TRUE);
 }
 
@@ -86,12 +103,14 @@ genmon_constructor(plugin_instance *p)
     gm->textsize = "medium";
     gm->textcolor = "darkblue";
     gm->max_text_len = 30;
+    gm->allow_pango_markup = 0;
     
     XCG(p->xc, "Command", &gm->command, str);
     XCG(p->xc, "TextSize", &gm->textsize, str);
     XCG(p->xc, "TextColor", &gm->textcolor, str);
     XCG(p->xc, "PollingTime", &gm->time, int);
     XCG(p->xc, "MaxTextLength", &gm->max_text_len, int);
+    XCG(p->xc, "AllowPangoMarkup", &gm->allow_pango_markup, int);
     
     gm->main = gtk_label_new(NULL);
     gtk_label_set_max_width_chars(GTK_LABEL(gm->main), gm->max_text_len);


### PR DESCRIPTION
This is a replacement for #20 with the correct author and committer name/email. Please replace #20 if you do forced pushes or just close without merge at your discretion. Either way is fine. Thanks.
